### PR TITLE
feat: add start dashboard and auth redirect

### DIFF
--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,8 +1,10 @@
 """Web application package for FastAPI endpoints."""
 from fastapi import FastAPI
-from .routes import admin, auth, index
+
+from .routes import admin, auth, index, start
 
 app = FastAPI()
 app.include_router(index.router)
 app.include_router(auth.router, prefix="/auth")
+app.include_router(start.router)
 app.include_router(admin.router, prefix="/admin")

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -90,7 +90,7 @@ async def telegram_callback(request: Request):
         if not created and user and user.role != role.value:
             await service.update_user_role(telegram_id, role)
 
-    response = RedirectResponse("/admin/users", status_code=303)
+    response = RedirectResponse("/start", status_code=303)
     response.set_cookie(
         "telegram_id",
         str(telegram_id),

--- a/web/routes/index.py
+++ b/web/routes/index.py
@@ -1,12 +1,37 @@
-from fastapi import APIRouter
+"""Root and helper routes for the web application."""
+
+from fastapi import APIRouter, Request
 from fastapi.responses import RedirectResponse
+
+from core.services.telegram import UserService
 
 router = APIRouter()
 
+
 @router.get("/", include_in_schema=False)
-async def index():
+async def index(request: Request) -> RedirectResponse:
+    """Redirect authenticated users to the dashboard.
+
+    Unauthenticated visitors are redirected to the login page instead.
+    """
+
+    user_id = request.cookies.get("telegram_id")
+    if user_id:
+        try:
+            telegram_id = int(user_id)
+        except ValueError:
+            telegram_id = None
+        if telegram_id is not None:
+            async with UserService() as service:
+                user = await service.get_user_by_telegram_id(telegram_id)
+                if user:
+                    return RedirectResponse("/start")
+
     return RedirectResponse("/auth/login")
 
+
 @router.get("/admin", include_in_schema=False)
-async def admin_index():
+async def admin_index() -> RedirectResponse:
+    """Convenience redirect for admin panel."""
+
     return RedirectResponse("/admin/users")

--- a/web/routes/start.py
+++ b/web/routes/start.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.future import select
+
+from core.models import Group, User, UserGroup
+from core.services.telegram import UserService
+from ..dependencies import get_current_user
+
+templates = Jinja2Templates(directory="web/templates")
+router = APIRouter()
+
+
+@router.get("/start", response_class=HTMLResponse)
+async def start_dashboard(request: Request, current_user: User = Depends(get_current_user)):
+    async with UserService() as service:
+        result = await service.session.execute(
+            select(Group).join(UserGroup, Group.telegram_id == UserGroup.group_id).where(
+                UserGroup.user_id == current_user.telegram_id
+            )
+        )
+        groups = result.scalars().all()
+    return templates.TemplateResponse(
+        "start.html", {"request": request, "user": current_user, "groups": groups}
+    )

--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="utf-8">
+    <title>Стартовый дашборд</title>
+</head>
+<body>
+<h1>Добро пожаловать, {{ user.first_name }}!</h1>
+<p>Ваша роль: {{ user.role }}</p>
+<h2>Ваши группы</h2>
+{% if groups %}
+<ul>
+    {% for group in groups %}
+    <li>{{ group.title }}</li>
+    {% endfor %}
+</ul>
+{% else %}
+<p>Вы не состоите ни в одной группе.</p>
+{% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redirect authenticated users to a new /start dashboard
- show user details and groups on /start
- send login callback to /start and integrate router

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac1138fd0832397aa08d261f77b8c