### PR TITLE
feat: add customizable user header

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -88,3 +88,71 @@ button, .button {
   border-radius: var(--radius);
   margin-bottom: var(--spacing);
 }
+
+/* Top bar with profile menu */
+.top-bar {
+  background-color: var(--color-accent-purple);
+  color: #fff;
+  padding: var(--spacing);
+  border-radius: var(--radius);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing);
+}
+
+.top-bar .welcome {
+  margin: 0;
+}
+
+.profile-menu {
+  position: relative;
+}
+
+.profile-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #fff;
+}
+
+.profile-icon.role-admin { background-color: var(--color-accent-purple); }
+.profile-icon.role-moderator { background-color: #f5a623; }
+.profile-icon.role-multiplayer { background-color: var(--color-accent-turquoise); }
+.profile-icon.role-single { background-color: #9e9e9e; }
+.profile-icon.role-ban { background-color: #e53e3e; }
+
+.dropdown-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  background: #fff;
+  color: #333;
+  border: 1px solid #ccc;
+  border-radius: var(--radius);
+  padding: 0.5rem 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  min-width: 150px;
+  z-index: 10;
+}
+
+.dropdown-menu a {
+  text-decoration: none;
+  color: #333;
+  margin-top: 0.5rem;
+}
+
+.dropdown-menu .role {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.hidden {
+  display: none;
+}

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -7,6 +7,20 @@ export function enableAccessibility() {
         document.documentElement.classList.toggle('high-contrast');
     });
 }
+export function initProfileMenu() {
+    const button = document.getElementById('profile-button');
+    const dropdown = document.getElementById('profile-dropdown');
+    if (!button || !dropdown)
+        return;
+    button.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        dropdown.classList.toggle('hidden');
+    });
+    document.addEventListener('click', () => {
+        dropdown.classList.add('hidden');
+    });
+}
 document.addEventListener('DOMContentLoaded', () => {
     enableAccessibility();
+    initProfileMenu();
 });

--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -1,8 +1,17 @@
 {% extends "layout.html" %}
 {% block title %}Дашборд{% endblock %}
 {% block content %}
-<h1>Привет, {{ user.first_name }}!</h1>
-<p>Роль: {{ role_name }}</p>
+<header class="top-bar">
+    <h1 class="welcome">Привет, {{ user.first_name }}!</h1>
+    <div class="profile-menu">
+        <div id="profile-button" class="profile-icon role-{{ role_name|lower }}">👤</div>
+        <div id="profile-dropdown" class="dropdown-menu hidden">
+            <div class="role">Роль: {{ role_name }}</div>
+            <a href="/profile/{{ user.telegram_id }}">Редактировать профиль</a>
+            <a href="/settings">Настройки</a>
+        </div>
+    </div>
+    </header>
 {% if groups %}
 <h2>Ваши группы</h2>
 <ul class="ui-table">


### PR DESCRIPTION
## Summary
- add top bar with greeting and profile dropdown
- style profile icon with role-based colors
- support toggling profile menu with JavaScript

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aacec1a37883239393f57c5d793c58