### PR TITLE
feat: add user header with profile menu

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -41,6 +41,78 @@ button, .button {
   cursor: pointer;
 }
 
+.user-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacing);
+  background-color: var(--color-accent-purple);
+  border-radius: var(--radius);
+  color: #fff;
+  margin-bottom: var(--spacing);
+}
+
+.profile-menu {
+  position: relative;
+}
+
+.profile-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background-color: var(--color-accent-turquoise);
+}
+
+.profile-icon.role-admin {
+  background-color: var(--color-accent-purple);
+}
+
+.profile-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  background: #fff;
+  color: #333;
+  padding: var(--spacing);
+  border-radius: var(--radius);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  display: none;
+  min-width: 150px;
+}
+
+.profile-menu.open .profile-dropdown {
+  display: block;
+}
+
+.profile-dropdown .role {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  text-transform: capitalize;
+}
+
+.profile-dropdown ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.profile-dropdown li {
+  margin-bottom: 0.5rem;
+}
+
+.profile-dropdown li:last-child {
+  margin-bottom: 0;
+}
+
+.profile-dropdown a {
+  color: inherit;
+  text-decoration: none;
+}
+
 .admin-panel {
   margin-top: 2rem;
   padding: var(--spacing);

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -7,6 +7,22 @@ export function enableAccessibility() {
         document.documentElement.classList.toggle('high-contrast');
     });
 }
+
+export function setupProfileMenu() {
+    const button = document.getElementById('profile-button');
+    const menu = document.querySelector('.profile-menu');
+    if (!button || !menu)
+        return;
+    button.addEventListener('click', () => {
+        menu.classList.toggle('open');
+    });
+    document.addEventListener('click', (e) => {
+        if (!menu.contains(e.target)) {
+            menu.classList.remove('open');
+        }
+    });
+}
 document.addEventListener('DOMContentLoaded', () => {
     enableAccessibility();
+    setupProfileMenu();
 });

--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -1,8 +1,19 @@
 {% extends "layout.html" %}
 {% block title %}Дашборд{% endblock %}
 {% block content %}
-<h1>Привет, {{ user.first_name }}!</h1>
-<p>Роль: {{ role_name }}</p>
+<header class="user-header">
+    <h1>Привет, {{ user.first_name }}!</h1>
+    <div class="profile-menu">
+        <div id="profile-button" class="profile-icon role-{{ role_name|lower }}">👤</div>
+        <div id="profile-dropdown" class="profile-dropdown">
+            <p class="role">{{ role_name }}</p>
+            <ul>
+                <li><a href="/profile/{{ user.telegram_id }}">Редактировать профиль</a></li>
+                <li><a href="/settings">Настройки</a></li>
+            </ul>
+        </div>
+    </div>
+</header>
 {% if groups %}
 <h2>Ваши группы</h2>
 <ul class="ui-table">


### PR DESCRIPTION
## Summary
- add greeting header with profile dropdown for all users
- style profile menu and role-based icon colors
- toggle profile dropdown on click via JS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aacec1a37883239393f57c5d793c58