### PR TITLE
Render admin pages inline on dashboard

### DIFF
--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -20,7 +20,30 @@ export function initProfileMenu() {
         dropdown.classList.add('hidden');
     });
 }
+
+export function initAdminMenu() {
+    const links = document.querySelectorAll('.admin-panel a[data-url]');
+    const container = document.getElementById('admin-content');
+    if (!links.length || !container)
+        return;
+    links.forEach((link) => {
+        link.addEventListener('click', async (ev) => {
+            ev.preventDefault();
+            const url = link.getAttribute('data-url');
+            if (!url)
+                return;
+            const resp = await fetch(url);
+            if (resp.ok) {
+                container.innerHTML = await resp.text();
+            }
+            else {
+                container.innerHTML = '<p>Ошибка загрузки</p>';
+            }
+        });
+    });
+}
 document.addEventListener('DOMContentLoaded', () => {
     enableAccessibility();
     initProfileMenu();
+    initAdminMenu();
 });

--- a/web/templates/admin/groups.html
+++ b/web/templates/admin/groups.html
@@ -1,21 +1,14 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Groups</title>
-</head>
-<body>
-    <h1>Groups</h1>
-    <ul>
-        {% for item in groups %}
-        <li>
-            {{ item.group.title }} ({{ item.group.participants_count }} members)
-            <ul>
-                {% for member in item.members %}
-                <li>{{ member.first_name }}</li>
-                {% endfor %}
-            </ul>
-        </li>
-        {% endfor %}
-    </ul>
-</body>
-</html>
+<h1>Groups</h1>
+<ul>
+    {% for item in groups %}
+    <li>
+        {{ item.group.title }} ({{ item.group.participants_count }} members)
+        <ul>
+            {% for member in item.members %}
+            <li>{{ member.first_name }}</li>
+            {% endfor %}
+        </ul>
+    </li>
+    {% endfor %}
+</ul>
+

--- a/web/templates/admin/users.html
+++ b/web/templates/admin/users.html
@@ -1,37 +1,28 @@
-<!DOCTYPE html>
-<html lang="ru">
-<head>
-    <meta charset="utf-8">
-    <title>Users</title>
-</head>
-<body>
-    <h1>Users</h1>
-    <p><a href="/admin/groups">Группы</a></p>
-    {% if users %}
-    <table border="1" cellpadding="4" cellspacing="0">
-        <thead>
-            <tr>
-                <th>ID</th>
-                <th>username</th>
-                <th>first_name</th>
-                <th>last_name</th>
-                <th>role</th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for user in users %}
-            <tr>
-                <td>{{ user.telegram_id }}</td>
-                <td>{{ user.username or '' }}</td>
-                <td>{{ user.first_name }}</td>
-                <td>{{ user.last_name or '' }}</td>
-                <td>{{ UserRole(user.role).name }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
-    {% else %}
-    <p>нет пользователей</p>
-    {% endif %}
-</body>
-</html>
+<h1>Users</h1>
+{% if users %}
+<table border="1" cellpadding="4" cellspacing="0">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>username</th>
+            <th>first_name</th>
+            <th>last_name</th>
+            <th>role</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for user in users %}
+        <tr>
+            <td>{{ user.telegram_id }}</td>
+            <td>{{ user.username or '' }}</td>
+            <td>{{ user.first_name }}</td>
+            <td>{{ user.last_name or '' }}</td>
+            <td>{{ UserRole(user.role).name }}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p>нет пользователей</p>
+{% endif %}
+

--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -26,11 +26,12 @@
 <footer class="admin-panel">
     <nav>
         <ul>
-            <li><a href="/admin/users">Пользователи</a></li>
-            <li><a href="/admin/groups">Группы</a></li>
-            <li><a href="/admin/settings">Настройки</a></li>
+            <li><a href="#" data-url="/admin/users" class="admin-link">Пользователи</a></li>
+            <li><a href="#" data-url="/admin/groups" class="admin-link">Группы</a></li>
+            <li><a href="#" data-url="/admin/settings" class="admin-link">Настройки</a></li>
         </ul>
     </nav>
 </footer>
+<section id="admin-content"></section>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Load admin pages below dashboard instead of redirecting
- Convert admin templates to partial snippets
- Add client-side JS to fetch and display admin content dynamically

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad47a9e6083239788b7856d3ce16c