### PR TITLE
Revamp navigation and profile editor

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -94,15 +94,29 @@ button, .button {
   background-color: var(--color-accent-purple);
   color: #fff;
   padding: var(--spacing);
-  border-radius: var(--radius);
+  border-radius: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: var(--spacing);
+  margin: 0 0 var(--spacing) 0;
+  width: 100%;
 }
 
 .top-bar .welcome {
   margin: 0;
+}
+
+.top-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.admin-menu { position: relative; }
+
+#admin-button {
+  cursor: pointer;
+  color: #fff;
 }
 
 .profile-menu {
@@ -151,6 +165,15 @@ button, .button {
 .dropdown-menu .role {
   font-weight: bold;
   margin-bottom: 0.5rem;
+}
+
+#login-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  text-align: center;
 }
 
 .hidden {

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -26,19 +26,31 @@ export function initProfileMenu() {
         if (!link)
             return;
         ev.preventDefault();
-        const resp = await fetch(link.href);
-        if (resp.ok) {
+        const method = link.dataset.method || 'GET';
+        const resp = await fetch(link.href, { method, credentials: 'include' });
+        if (resp.redirected) {
+            window.location.href = resp.url;
+        }
+        else if (resp.ok) {
             content.innerHTML = await resp.text();
         }
         dropdown.classList.add('hidden');
     });
 }
-export function initAdminPanel() {
-    const panel = document.querySelector('.admin-panel');
+export function initAdminMenu() {
+    const button = document.getElementById('admin-button');
+    const dropdown = document.getElementById('admin-dropdown');
     const content = document.getElementById('main-content');
-    if (!panel || !content)
+    if (!button || !dropdown || !content)
         return;
-    panel.addEventListener('click', async (ev) => {
+    button.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        dropdown.classList.toggle('hidden');
+    });
+    document.addEventListener('click', () => {
+        dropdown.classList.add('hidden');
+    });
+    dropdown.addEventListener('click', async (ev) => {
         const target = ev.target;
         const link = target === null || target === void 0 ? void 0 : target.closest('a');
         if (!link)
@@ -47,14 +59,15 @@ export function initAdminPanel() {
         const url = link.dataset.adminEndpoint;
         if (!url)
             return;
-        const resp = await fetch(url);
+        const resp = await fetch(url, { credentials: 'include' });
         if (resp.ok) {
             content.innerHTML = await resp.text();
         }
+        dropdown.classList.add('hidden');
     });
 }
 document.addEventListener('DOMContentLoaded', () => {
     enableAccessibility();
     initProfileMenu();
-    initAdminPanel();
+    initAdminMenu();
 });

--- a/web/static/ts/main.ts
+++ b/web/static/ts/main.ts
@@ -24,7 +24,37 @@ export function initProfileMenu() {
     const link = target?.closest('a') as HTMLAnchorElement | null;
     if (!link) return;
     ev.preventDefault();
-    const resp = await fetch(link.href);
+    const method = link.dataset.method || 'GET';
+    const resp = await fetch(link.href, { method, credentials: 'include' });
+    if (resp.redirected) {
+      window.location.href = resp.url;
+    } else if (resp.ok) {
+      content.innerHTML = await resp.text();
+    }
+    dropdown.classList.add('hidden');
+  });
+}
+
+export function initAdminMenu() {
+  const button = document.getElementById('admin-button');
+  const dropdown = document.getElementById('admin-dropdown');
+  const content = document.getElementById('main-content');
+  if (!button || !dropdown || !content) return;
+  button.addEventListener('click', (ev) => {
+    ev.stopPropagation();
+    dropdown.classList.toggle('hidden');
+  });
+  document.addEventListener('click', () => {
+    dropdown.classList.add('hidden');
+  });
+  dropdown.addEventListener('click', async (ev) => {
+    const target = ev.target as HTMLElement | null;
+    const link = target?.closest('a') as HTMLAnchorElement | null;
+    if (!link) return;
+    ev.preventDefault();
+    const url = link.dataset.adminEndpoint;
+    if (!url) return;
+    const resp = await fetch(url, { credentials: 'include' });
     if (resp.ok) {
       content.innerHTML = await resp.text();
     }
@@ -32,26 +62,8 @@ export function initProfileMenu() {
   });
 }
 
-export function initAdminPanel() {
-  const panel = document.querySelector('.admin-panel');
-  const content = document.getElementById('main-content');
-  if (!panel || !content) return;
-  panel.addEventListener('click', async (ev) => {
-    const target = ev.target as HTMLElement | null;
-    const link = target?.closest('a') as HTMLAnchorElement | null;
-    if (!link) return;
-    ev.preventDefault();
-    const url = link.dataset.adminEndpoint;
-    if (!url) return;
-    const resp = await fetch(url);
-    if (resp.ok) {
-      content.innerHTML = await resp.text();
-    }
-  });
-}
-
 document.addEventListener('DOMContentLoaded', () => {
   enableAccessibility();
   initProfileMenu();
-  initAdminPanel();
+  initAdminMenu();
 });

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -1,31 +1,36 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Telegram Login</title>
-</head>
-<body>
-{% if mode == 'redirect' %}
-<script async src="https://telegram.org/js/telegram-widget.js?19"
-        data-telegram-login="{{ bot_username }}"
-        data-size="large"
-        data-auth-url="/auth/callback">
-</script>
-{% else %}
-<script async src="https://telegram.org/js/telegram-widget.js?19"
-        data-telegram-login="{{ bot_username }}"
-        data-size="large"
-        data-onauth="onTelegramAuth(user)">
-</script>
+{% extends "layout.html" %}
+{% block title %}Вход{% endblock %}
+{% block content %}
+<div id="login-page" class="ui-layout">
+  <h1>Вход через Telegram</h1>
+  <script src="https://telegram.org/js/telegram-widget.js?22"
+          data-telegram-login="{{ bot_username }}"
+          data-size="large"
+          data-userpic="false"
+          data-request-access="write"
+          data-lang="ru"
+          data-onauth="onTelegramAuth(user)"></script>
+</div>
 <script>
-    function onTelegramAuth(user) {
-        fetch('/auth/callback', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify(user),
-            credentials: 'same-origin'
-        }).then(resp => resp.json()).then(() => window.location = '/admin');
-    }
+async function onTelegramAuth(user) {
+  const form = new URLSearchParams();
+  for (const [k,v] of Object.entries(user)) { form.append(k, v); }
+  const resp = await fetch('/auth/callback{{ next_query }}', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+    credentials: 'same-origin'
+  });
+  if (resp.redirected) {
+    window.location = resp.url;
+  } else {
+    let detail = 'Ошибка авторизации';
+    try {
+      const j = await resp.json();
+      if (j && j.detail) detail = j.detail;
+    } catch (_) {}
+    alert(detail);
+  }
+}
 </script>
-{% endif %}
-</body>
-</html>
+{% endblock %}

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="/static/css/style.css">
     <script type="module" src="/static/js/main.js"></script>
 </head>
-<body class="ui-layout">
+<body>
     {% block content %}{% endblock %}
 </body>
 </html>

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -1,7 +1,27 @@
-<h1>{{ user.first_name }} {{ user.last_name or '' }}</h1>
-<table class="ui-table">
-    <tr><th>Username</th><td>{{ user.username }}</td></tr>
-    <tr><th>Email</th><td>{{ user.email }}</td></tr>
-    <tr><th>Phone</th><td>{{ user.phone }}</td></tr>
-    <tr><th>Role</th><td>{{ user.role }}</td></tr>
-</table>
+<h1>Редактирование профиля</h1>
+<form id="profile-edit-form" class="ui-form" method="post">
+    <label for="first_name">Имя</label>
+    <input id="first_name" name="first_name" value="{{ user.first_name or '' }}">
+    <label for="last_name">Фамилия</label>
+    <input id="last_name" name="last_name" value="{{ user.last_name or '' }}">
+    <label for="username">Username</label>
+    <input id="username" name="username" value="{{ user.username or '' }}">
+    <label for="birth_date">Дата рождения</label>
+    <input id="birth_date" type="date" name="birth_date" value="{{ user.birth_date or '' }}">
+    <button type="submit">Сохранить</button>
+</form>
+<script>
+const form = document.getElementById('profile-edit-form');
+if (form) {
+  form.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const formData = new FormData(form);
+    const resp = await fetch(window.location.pathname, {method: 'POST', body: formData, credentials: 'include'});
+    if (resp.ok) {
+      const html = await resp.text();
+      const container = document.getElementById('main-content');
+      if (container) container.innerHTML = html;
+    }
+  });
+}
+</script>

--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -3,36 +3,40 @@
 {% block content %}
 <header class="top-bar">
     <h1 class="welcome">Привет, {{ user.first_name }}!</h1>
-    <div class="profile-menu">
-        <div id="profile-button" class="profile-icon role-{{ role_name|lower }}">👤</div>
-        <div id="profile-dropdown" class="dropdown-menu hidden">
-            <div class="role">Роль: {{ role_name }}</div>
-            <a href="/profile/{{ user.telegram_id }}">Редактировать профиль</a>
-            <a href="/settings">Настройки</a>
+    <div class="top-right">
+        {% if is_admin %}
+        <div class="admin-menu">
+            <div id="admin-button">Админ</div>
+            <div id="admin-dropdown" class="dropdown-menu hidden">
+                <a href="#" data-admin-endpoint="/admin/users">Пользователи</a>
+                <a href="#" data-admin-endpoint="/admin/groups">Группы</a>
+                <a href="#" data-admin-endpoint="/admin/settings">Настройки</a>
+            </div>
+        </div>
+        {% endif %}
+        <div class="profile-menu">
+            <div id="profile-button" class="profile-icon role-{{ role_name|lower }}">👤</div>
+            <div id="profile-dropdown" class="dropdown-menu hidden">
+                <div class="role">Роль: {{ role_name }}</div>
+                <a href="/profile/{{ user.telegram_id }}">Редактировать профиль</a>
+                <a href="/settings">Настройки</a>
+                <a href="/auth/logout" data-method="post">Выйти</a>
+            </div>
         </div>
     </div>
     </header>
-<div id="main-content">
-{% if groups %}
-<h2>Ваши группы</h2>
-<ul class="ui-table">
-{% for g in groups %}
-    <li>{{ g.title }}</li>
-{% endfor %}
-</ul>
-{% else %}
-<p>Вы не состоите ни в одной группе.</p>
-{% endif %}
+<div class="ui-layout">
+    <div id="main-content">
+    {% if groups %}
+    <h2>Ваши группы</h2>
+    <ul class="ui-table">
+    {% for g in groups %}
+        <li>{{ g.title }}</li>
+    {% endfor %}
+    </ul>
+    {% else %}
+    <p>Вы не состоите ни в одной группе.</p>
+    {% endif %}
+    </div>
 </div>
-{% if is_admin %}
-<footer class="admin-panel">
-    <nav>
-        <ul>
-            <li><a href="#" data-admin-endpoint="/admin/users">Пользователи</a></li>
-            <li><a href="#" data-admin-endpoint="/admin/groups">Группы</a></li>
-            <li><a href="#" data-admin-endpoint="/admin/settings">Настройки</a></li>
-        </ul>
-    </nav>
-</footer>
-{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- expand the top menu to full width and merge admin links into an "Админ" dropdown
- add logout link and profile editor skeleton with name, username and birthday fields
- restyle login page to match app theme and center the Telegram auth widget

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aadcb52ee48323b01aede770768b2c