### PR TITLE
Fix menu width and profile edit behavior

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -100,10 +100,16 @@ button, .button {
   align-items: center;
   margin: 0 0 var(--spacing) 0;
   width: 100%;
+  box-sizing: border-box;
 }
 
 .top-bar .welcome {
   margin: 0;
+}
+
+.top-bar .welcome a {
+  color: inherit;
+  text-decoration: none;
 }
 
 .top-right {

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -33,6 +33,7 @@ export function initProfileMenu() {
         }
         else if (resp.ok) {
             content.innerHTML = await resp.text();
+            initProfileEditForm();
         }
         dropdown.classList.add('hidden');
     });
@@ -62,12 +63,36 @@ export function initAdminMenu() {
         const resp = await fetch(url, { credentials: 'include' });
         if (resp.ok) {
             content.innerHTML = await resp.text();
+            initProfileEditForm();
         }
         dropdown.classList.add('hidden');
+    });
+}
+export function initProfileEditForm() {
+    const form = document.getElementById('profile-edit-form');
+    if (!form)
+        return;
+    form.addEventListener('submit', async (ev) => {
+        ev.preventDefault();
+        const formData = new FormData(form);
+        const resp = await fetch(window.location.pathname, {
+            method: 'POST',
+            body: formData,
+            credentials: 'include',
+        });
+        if (resp.ok) {
+            const html = await resp.text();
+            const container = document.getElementById('main-content');
+            if (container) {
+                container.innerHTML = html;
+                initProfileEditForm();
+            }
+        }
     });
 }
 document.addEventListener('DOMContentLoaded', () => {
     enableAccessibility();
     initProfileMenu();
     initAdminMenu();
+    initProfileEditForm();
 });

--- a/web/static/ts/main.ts
+++ b/web/static/ts/main.ts
@@ -30,6 +30,7 @@ export function initProfileMenu() {
       window.location.href = resp.url;
     } else if (resp.ok) {
       content.innerHTML = await resp.text();
+      initProfileEditForm();
     }
     dropdown.classList.add('hidden');
   });
@@ -57,8 +58,31 @@ export function initAdminMenu() {
     const resp = await fetch(url, { credentials: 'include' });
     if (resp.ok) {
       content.innerHTML = await resp.text();
+      initProfileEditForm();
     }
     dropdown.classList.add('hidden');
+  });
+}
+
+export function initProfileEditForm() {
+  const form = document.getElementById('profile-edit-form') as HTMLFormElement | null;
+  if (!form) return;
+  form.addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const formData = new FormData(form);
+    const resp = await fetch(window.location.pathname, {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    });
+    if (resp.ok) {
+      const html = await resp.text();
+      const container = document.getElementById('main-content');
+      if (container) {
+        container.innerHTML = html;
+        initProfileEditForm();
+      }
+    }
   });
 }
 
@@ -66,4 +90,5 @@ document.addEventListener('DOMContentLoaded', () => {
   enableAccessibility();
   initProfileMenu();
   initAdminMenu();
+  initProfileEditForm();
 });

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -10,18 +10,3 @@
     <input id="birth_date" type="date" name="birth_date" value="{{ user.birth_date or '' }}">
     <button type="submit">Сохранить</button>
 </form>
-<script>
-const form = document.getElementById('profile-edit-form');
-if (form) {
-  form.addEventListener('submit', async (ev) => {
-    ev.preventDefault();
-    const formData = new FormData(form);
-    const resp = await fetch(window.location.pathname, {method: 'POST', body: formData, credentials: 'include'});
-    if (resp.ok) {
-      const html = await resp.text();
-      const container = document.getElementById('main-content');
-      if (container) container.innerHTML = html;
-    }
-  });
-}
-</script>

--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -2,7 +2,7 @@
 {% block title %}Дашборд{% endblock %}
 {% block content %}
 <header class="top-bar">
-    <h1 class="welcome">Привет, {{ user.first_name }}!</h1>
+    <h1 class="welcome"><a href="/">Привет, {{ user.first_name }}!</a></h1>
     <div class="top-right">
         {% if is_admin %}
         <div class="admin-menu">


### PR DESCRIPTION
## Summary
- prevent top bar from overflowing and make greeting link to home
- handle profile edit form submission globally so editing works

## Testing
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiogram')*


------
https://chatgpt.com/codex/tasks/task_e_68aae92e4a288323b803745e9464f0ba