### PR TITLE
Fix login header width and restore interactivity

### DIFF
--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -1,11 +1,11 @@
 {% extends "layout.html" %}
 {% block title %}Вход{% endblock %}
 {% block content %}
-  <div id="login-page" class="ui-layout">
-    <div class="top-bar">
-      <h1 class="welcome">Привет, гость, авторизуйся для дальнейшей работы</h1>
-    </div>
+  <div class="top-bar">
+    <h1 class="welcome">Привет, гость, авторизуйся для дальнейшей работы</h1>
+  </div>
 
+  <div id="login-page" class="ui-layout">
     <h2>Вход через Telegram</h2>
     <div>
       <script async src="https://telegram.org/js/telegram-widget.js?22"

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>{% block title %}LeonidBot{% endblock %}</title>
     <link rel="stylesheet" href="{{ url_for('static', path='css/style.css') }}">
-    <script defer src="{{ url_for('static', path='js/main.js') }}"></script>
+    <script type="module" src="{{ url_for('static', path='js/main.js') }}"></script>
 </head>
 <body>
     {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- Ensure login page top bar spans full width
- Load JS bundle as ES module to restore interactive menus

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aafb8bf45883239ebc3c2c021e1eea