### PR TITLE
Refactor profile interface and contact handling

### DIFF
--- a/core/services/telegram.py
+++ b/core/services/telegram.py
@@ -244,6 +244,31 @@ class UserService:
         groups = await self.list_user_groups(telegram_id)
         return user, groups
 
+    async def get_contact_info(self, telegram_id: int) -> Dict[str, Any]:
+        """Возвращает словарь с контактными данными пользователя."""
+        user, groups = await self.get_user_and_groups(telegram_id)
+        if not user:
+            return {}
+        display_name = (
+            user.full_display_name
+            or f"{user.first_name} {user.last_name or ''}".strip()
+        )
+        return {
+            "user": user,
+            "groups": groups,
+            "telegram_id": user.telegram_id,
+            "username": f"@{user.username}" if user.username else None,
+            "full_display_name": user.full_display_name,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "display_name": display_name,
+            "email": user.email,
+            "phone": user.phone,
+            "birthday": user.birthday.strftime("%d.%m.%Y") if user.birthday else None,
+            "language_code": user.language_code,
+            "role_name": UserRole(user.role).name,
+        }
+
     async def update_user_profile(self, telegram_id: int, data: Dict[str, Any]) -> Optional[User]:
         """Обновляет данные профиля пользователя."""
         user = await self.get_user_by_telegram_id(telegram_id)
@@ -251,6 +276,7 @@ class UserService:
             return None
 
         allowed_fields = {
+            "full_display_name",
             "first_name",
             "last_name",
             "username",

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -22,6 +22,26 @@ class FakeService:
     async def get_user_and_groups(self, telegram_id: int):
         return self.users.get(telegram_id), []
 
+    async def get_contact_info(self, telegram_id: int):
+        user = self.users.get(telegram_id)
+        if not user:
+            return {}
+        return {
+            "user": user,
+            "groups": [],
+            "telegram_id": user.telegram_id,
+            "username": f"@{user.username}" if user.username else None,
+            "full_display_name": user.full_display_name,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "display_name": user.full_display_name or user.first_name,
+            "email": user.email,
+            "phone": user.phone,
+            "birthday": user.birthday.strftime("%d.%m.%Y") if user.birthday else None,
+            "language_code": user.language_code,
+            "role_name": UserRole(user.role).name,
+        }
+
     async def update_user_profile(self, telegram_id: int, data):
         user = self.users.get(telegram_id)
         if user:
@@ -63,7 +83,12 @@ def test_higher_role_cannot_view_others():
 
 
 def test_single_user_can_update_self():
-    res = client.post("/profile/1", headers=auth_header(1), data={"username": "alice_new"})
+    res = client.post(
+        "/profile/1",
+        headers=auth_header(1),
+        data={"username": "alice_new"},
+        follow_redirects=True,
+    )
     assert res.status_code == 200
     assert "alice_new" in res.text
 

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -25,6 +25,12 @@ h1, h2, h3 {
 
 h1 { font-size: var(--font-size-xl); }
 
+.page-title {
+  padding: 0;
+  margin: 0 0 var(--spacing) 0;
+  font-size: 1.5rem;
+}
+
 .ui-layout {
   max-width: 800px;
   margin: 0 auto;

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -2,43 +2,72 @@
 {% block title %}Профиль{% endblock %}
 {% block content %}
 <header class="top-bar">
-    <h1 class="welcome"><a href="/">Профиль</a></h1>
+    <h1 class="welcome"><a href="/">Привет, {{ current_user.first_name }}!</a></h1>
+    <div class="top-right">
+        {% if is_admin %}
+        <div class="admin-menu">
+            <div id="admin-button">Админ</div>
+            <div id="admin-dropdown" class="dropdown-menu hidden">
+                <a href="#" data-admin-endpoint="/admin/users">Пользователи</a>
+                <a href="#" data-admin-endpoint="/admin/groups">Группы</a>
+                <a href="#" data-admin-endpoint="/admin/settings">Настройки</a>
+            </div>
+        </div>
+        {% endif %}
+        <div class="profile-menu">
+            <div id="profile-button" class="profile-icon role-{{ current_role_name|lower }}">👤</div>
+            <div id="profile-dropdown" class="dropdown-menu hidden">
+                <div class="role">Роль: {{ current_role_name }}</div>
+                <a href="/profile/{{ current_user.telegram_id }}">Профиль</a>
+                <a href="/settings">Настройки</a>
+                <a href="/auth/logout" data-method="post">Выйти</a>
+            </div>
+        </div>
+    </div>
 </header>
 <div class="ui-layout">
-    {% if editing %}
-    <form class="ui-form" method="post" action="/profile/{{ user.telegram_id }}">
-        <label>Имя</label>
-        <input type="text" name="first_name" value="{{ user.first_name }}" required>
-        <label>Фамилия</label>
-        <input type="text" name="last_name" value="{{ user.last_name or '' }}">
-        <label>Username</label>
-        <input type="text" name="username" value="{{ user.username or '' }}">
-        <label>День рождения</label>
-        <input type="date" name="birthday" value="{{ user.birthday or '' }}">
-        <label>Язык</label>
-        <input type="text" name="language_code" value="{{ user.language_code or '' }}">
-        <label>Email</label>
-        <input type="email" name="email" value="{{ user.email or '' }}">
-        <label>Телефон</label>
-        <input type="text" name="phone" value="{{ user.phone or '' }}">
-        <button type="submit" class="button">Сохранить</button>
-        <button type="button" class="button" onclick="location.href='/profile/{{ user.telegram_id }}'">Отменить</button>
-    </form>
-    {% else %}
-    <h2>{{ user.first_name }} {{ user.last_name or '' }}</h2>
-    <p><strong>Username:</strong> @{{ user.username or '' }}</p>
-    <p><strong>День рождения:</strong> {{ user.birthday or 'не указано' }}</p>
-    <p><strong>Язык:</strong> {{ user.language_code or 'не указан' }}</p>
-    <p><strong>Роль:</strong> {{ role_name }}</p>
-    {% if groups %}
-    <h2>Ваши группы</h2>
-    <ul class="ui-table">
-        {% for g in groups %}<li>{{ g.title }}</li>{% endfor %}
-    </ul>
-    {% else %}
-    <p>Группы отсутствуют.</p>
-    {% endif %}
-    <button class="button" onclick="location.href='/profile/{{ user.telegram_id }}?edit=true'">Редактировать</button>
-    {% endif %}
+    <div id="main-content">
+        <h2 class="page-title">Профиль</h2>
+        {% if editing %}
+        <form class="ui-form" method="post" action="/profile/{{ user.telegram_id }}">
+            <label>Отображаемое имя</label>
+            <input type="text" name="full_display_name" value="{{ user.full_display_name or '' }}">
+            <label>Имя</label>
+            <input type="text" name="first_name" value="{{ user.first_name }}" required>
+            <label>Фамилия</label>
+            <input type="text" name="last_name" value="{{ user.last_name or '' }}">
+            <label>Username</label>
+            <input type="text" name="username" value="{{ user.username or '' }}">
+            <label>Email</label>
+            <input type="email" name="email" value="{{ user.email or '' }}">
+            <label>Телефон</label>
+            <input type="text" name="phone" value="{{ user.phone or '' }}">
+            <label>День рождения</label>
+            <input type="date" name="birthday" value="{{ user.birthday.strftime('%Y-%m-%d') if user.birthday else '' }}">
+            <label>Язык</label>
+            <input type="text" name="language_code" value="{{ user.language_code or '' }}">
+            <button type="submit" class="button">Сохранить</button>
+            <button type="button" class="button" onclick="location.href='/profile/{{ user.telegram_id }}'">Отмена</button>
+        </form>
+        {% else %}
+        <p><strong>Имя:</strong> {{ info.display_name }}</p>
+        <p><strong>Telegram ID:</strong> {{ info.telegram_id }}</p>
+        <p><strong>Username:</strong> {{ info.username or 'не указан' }}</p>
+        <p><strong>Email:</strong> {{ info.email or 'не указано' }}</p>
+        <p><strong>Телефон:</strong> {{ info.phone or 'не указан' }}</p>
+        <p><strong>День рождения:</strong> {{ info.birthday or 'не указано' }}</p>
+        <p><strong>Язык:</strong> {{ info.language_code or 'не указан' }}</p>
+        <p><strong>Роль:</strong> {{ role_name }}</p>
+        {% if groups %}
+        <h3>Группы</h3>
+        <ul class="ui-table">
+            {% for g in groups %}<li>{{ g.title }}</li>{% endfor %}
+        </ul>
+        {% else %}
+        <p>Группы отсутствуют.</p>
+        {% endif %}
+        <button class="button" onclick="location.href='/profile/{{ user.telegram_id }}?edit=true'">Редактировать профиль</button>
+        {% endif %}
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- share profile info via new `UserService.get_contact_info` and allow updating `full_display_name`
- redesign profile page with unified top bar, edit form and view mode
- parse birthday inputs correctly and reuse contact info in bot `/contact` command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab257e8e2c83238ed061aac27242d3