### PR TITLE
Refactor navigation to separate pages

### DIFF
--- a/web/routes/profile.py
+++ b/web/routes/profile.py
@@ -71,13 +71,13 @@ async def view_profile(
 
     context = {
         "request": request,
-        "user": info["user"],
+        "profile_user": info["user"],
         "info": info,
         "groups": info["groups"],
         "editing": edit,
         "role_name": info["role_name"],
-        "current_user": current_user,
         "current_role_name": UserRole(current_user.role).name,
+        "user": current_user,
         "is_admin": current_user.is_admin,
         "page_title": "Профиль",
     }

--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -2,14 +2,25 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Depends
 from fastapi.templating import Jinja2Templates
+
+from core.models import User, UserRole
+from ..dependencies import get_current_user
 
 router = APIRouter()
 
 TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates"
 templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 
+
 @router.get("/settings", include_in_schema=False)
-async def settings_page(request: Request):
-    return templates.TemplateResponse(request, "settings.html", {})
+async def settings_page(request: Request, current_user: User = Depends(get_current_user)):
+    context = {
+        "request": request,
+        "user": current_user,
+        "role_name": UserRole(current_user.role).name,
+        "is_admin": current_user.is_admin,
+        "page_title": "Настройки",
+    }
+    return templates.TemplateResponse("settings.html", context)

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -10,8 +10,7 @@ export function enableAccessibility() {
 export function initProfileMenu() {
     const button = document.getElementById('profile-button');
     const dropdown = document.getElementById('profile-dropdown');
-    const content = document.getElementById('main-content');
-    if (!button || !dropdown || !content)
+    if (!button || !dropdown)
         return;
     button.addEventListener('click', (ev) => {
         ev.stopPropagation();
@@ -25,45 +24,16 @@ export function initProfileMenu() {
         const link = target === null || target === void 0 ? void 0 : target.closest('a');
         if (!link)
             return;
-        ev.preventDefault();
-        const method = link.dataset.method || 'GET';
-        const resp = await fetch(link.href, { method, credentials: 'include' });
-        if (resp.redirected) {
-            window.location.href = resp.url;
-        }
-        else if (resp.ok) {
-            content.innerHTML = await resp.text();
-            initProfileEditForm();
-        }
-        dropdown.classList.add('hidden');
-    });
-}
-export function initAdminMenu() {
-    const button = document.getElementById('admin-button');
-    const dropdown = document.getElementById('admin-dropdown');
-    const content = document.getElementById('main-content');
-    if (!button || !dropdown || !content)
-        return;
-    button.addEventListener('click', (ev) => {
-        ev.stopPropagation();
-        dropdown.classList.toggle('hidden');
-    });
-    document.addEventListener('click', () => {
-        dropdown.classList.add('hidden');
-    });
-    dropdown.addEventListener('click', async (ev) => {
-        const target = ev.target;
-        const link = target === null || target === void 0 ? void 0 : target.closest('a');
-        if (!link)
-            return;
-        ev.preventDefault();
-        const url = link.dataset.adminEndpoint;
-        if (!url)
-            return;
-        const resp = await fetch(url, { credentials: 'include' });
-        if (resp.ok) {
-            content.innerHTML = await resp.text();
-            initProfileEditForm();
+        const method = link.dataset.method;
+        if (method && method.toUpperCase() !== 'GET') {
+            ev.preventDefault();
+            const resp = await fetch(link.href, { method, credentials: 'include' });
+            if (resp.redirected) {
+                window.location.href = resp.url;
+            }
+            else if (resp.ok) {
+                window.location.reload();
+            }
         }
         dropdown.classList.add('hidden');
     });
@@ -93,6 +63,5 @@ export function initProfileEditForm() {
 document.addEventListener('DOMContentLoaded', () => {
     enableAccessibility();
     initProfileMenu();
-    initAdminMenu();
     initProfileEditForm();
 });

--- a/web/templates/admin/groups.html
+++ b/web/templates/admin/groups.html
@@ -1,13 +1,22 @@
-<h1>Groups</h1>
-<ul>
-    {% for item in groups %}
-    <li>
-        {{ item.group.title }} ({{ item.group.participants_count }} members)
+{% extends "layout.html" %}
+{% block title %}Админ - Группы{% endblock %}
+{% block content %}
+{% include "header.html" %}
+<div class="ui-layout">
+    <div id="main-content">
+        <h1>Groups</h1>
         <ul>
-            {% for member in item.members %}
-            <li>{{ member.first_name }}</li>
+            {% for item in groups %}
+            <li>
+                {{ item.group.title }} ({{ item.group.participants_count }} members)
+                <ul>
+                    {% for member in item.members %}
+                    <li>{{ member.first_name }}</li>
+                    {% endfor %}
+                </ul>
+            </li>
             {% endfor %}
         </ul>
-    </li>
-    {% endfor %}
-</ul>
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/admin/settings.html
+++ b/web/templates/admin/settings.html
@@ -1,2 +1,11 @@
-<h1>Админ настройки</h1>
-<p>Настройки администратора находятся в разработке.</p>
+{% extends "layout.html" %}
+{% block title %}Админ - Настройки{% endblock %}
+{% block content %}
+{% include "header.html" %}
+<div class="ui-layout">
+    <div id="main-content">
+        <h1>Админ настройки</h1>
+        <p>Настройки администратора находятся в разработке.</p>
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/admin/users.html
+++ b/web/templates/admin/users.html
@@ -1,27 +1,36 @@
-<h1>Users</h1>
-{% if users %}
-<table border="1" cellpadding="4" cellspacing="0">
-    <thead>
-        <tr>
-            <th>ID</th>
-            <th>username</th>
-            <th>first_name</th>
-            <th>last_name</th>
-            <th>role</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for user in users %}
-        <tr>
-            <td>{{ user.telegram_id }}</td>
-            <td>{{ user.username or '' }}</td>
-            <td>{{ user.first_name }}</td>
-            <td>{{ user.last_name or '' }}</td>
-            <td>{{ UserRole(user.role).name }}</td>
-        </tr>
-    {% endfor %}
-    </tbody>
-</table>
-{% else %}
-<p>нет пользователей</p>
-{% endif %}
+{% extends "layout.html" %}
+{% block title %}Админ - Пользователи{% endblock %}
+{% block content %}
+{% include "header.html" %}
+<div class="ui-layout">
+    <div id="main-content">
+        <h1>Users</h1>
+        {% if users %}
+        <table border="1" cellpadding="4" cellspacing="0">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>username</th>
+                    <th>first_name</th>
+                    <th>last_name</th>
+                    <th>role</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for user in users %}
+                <tr>
+                    <td>{{ user.telegram_id }}</td>
+                    <td>{{ user.username or '' }}</td>
+                    <td>{{ user.first_name }}</td>
+                    <td>{{ user.last_name or '' }}</td>
+                    <td>{{ UserRole(user.role).name }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p>нет пользователей</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -1,0 +1,24 @@
+{% set header_user = current_user if current_user is defined else user %}
+{% set header_role = current_role_name if current_role_name is defined else role_name %}
+<header class="top-bar">
+    <div class="top-left">
+        <h1 class="welcome"><a href="/">Привет, {{ header_user.first_name }}!</a></h1>
+    </div>
+    <div class="top-center">
+        <h2 class="page-title">{{ page_title }}</h2>
+    </div>
+    <div class="top-right">
+        {% if is_admin %}
+        <div class="admin-menu"><a href="/admin">Админ</a></div>
+        {% endif %}
+        <div class="profile-menu">
+            <div id="profile-button" class="profile-icon role-{{ header_role|lower }}">👤</div>
+            <div id="profile-dropdown" class="dropdown-menu hidden">
+                <div class="role">Роль: {{ header_role }}</div>
+                <a href="/profile/{{ header_user.telegram_id }}">Профиль</a>
+                <a href="/settings">Настройки</a>
+                <a href="/auth/logout" data-method="post">Выйти</a>
+            </div>
+        </div>
+    </div>
+</header>

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -1,57 +1,29 @@
 {% extends "layout.html" %}
 {% block title %}Профиль{% endblock %}
 {% block content %}
-<header class="top-bar">
-    <div class="top-left">
-        <h1 class="welcome"><a href="/">Привет, {{ current_user.first_name }}!</a></h1>
-    </div>
-    <div class="top-center">
-        <h2 class="page-title">{{ page_title }}</h2>
-    </div>
-    <div class="top-right">
-        {% if is_admin %}
-        <div class="admin-menu">
-            <div id="admin-button">Админ</div>
-            <div id="admin-dropdown" class="dropdown-menu hidden">
-                <a href="#" data-admin-endpoint="/admin/users">Пользователи</a>
-                <a href="#" data-admin-endpoint="/admin/groups">Группы</a>
-                <a href="#" data-admin-endpoint="/admin/settings">Настройки</a>
-            </div>
-        </div>
-        {% endif %}
-        <div class="profile-menu">
-            <div id="profile-button" class="profile-icon role-{{ current_role_name|lower }}">👤</div>
-            <div id="profile-dropdown" class="dropdown-menu hidden">
-                <div class="role">Роль: {{ current_role_name }}</div>
-                <a href="/profile/{{ current_user.telegram_id }}">Профиль</a>
-                <a href="/settings">Настройки</a>
-                <a href="/auth/logout" data-method="post">Выйти</a>
-            </div>
-        </div>
-    </div>
-</header>
+{% include "header.html" %}
 <div class="ui-layout">
     <div id="main-content">
         {% if editing %}
-        <form class="ui-form" method="post" action="/profile/{{ user.telegram_id }}">
+        <form class="ui-form" method="post" action="/profile/{{ profile_user.telegram_id }}">
             <label>Отображаемое имя</label>
-            <input type="text" name="full_display_name" value="{{ user.full_display_name or '' }}">
+            <input type="text" name="full_display_name" value="{{ profile_user.full_display_name or '' }}">
             <label>Имя</label>
-            <input type="text" name="first_name" value="{{ user.first_name }}" required>
+            <input type="text" name="first_name" value="{{ profile_user.first_name }}" required>
             <label>Фамилия</label>
-            <input type="text" name="last_name" value="{{ user.last_name or '' }}">
+            <input type="text" name="last_name" value="{{ profile_user.last_name or '' }}">
             <label>Username</label>
-            <input type="text" name="username" value="{{ user.username or '' }}">
+            <input type="text" name="username" value="{{ profile_user.username or '' }}">
             <label>Email</label>
-            <input type="email" name="email" value="{{ user.email or '' }}">
+            <input type="email" name="email" value="{{ profile_user.email or '' }}">
             <label>Телефон</label>
-            <input type="text" name="phone" value="{{ user.phone or '' }}">
+            <input type="text" name="phone" value="{{ profile_user.phone or '' }}">
             <label>День рождения</label>
-            <input type="date" name="birthday" value="{{ user.birthday.strftime('%Y-%m-%d') if user.birthday else '' }}">
+            <input type="date" name="birthday" value="{{ profile_user.birthday.strftime('%Y-%m-%d') if profile_user.birthday else '' }}">
             <label>Язык</label>
-            <input type="text" name="language_code" value="{{ user.language_code or '' }}">
+            <input type="text" name="language_code" value="{{ profile_user.language_code or '' }}">
             <button type="submit" class="button">Сохранить</button>
-            <button type="button" class="button" onclick="location.href='/profile/{{ user.telegram_id }}'">Отмена</button>
+            <button type="button" class="button" onclick="location.href='/profile/{{ profile_user.telegram_id }}'">Отмена</button>
         </form>
         {% else %}
         <p><strong>Имя:</strong> {{ info.display_name }}</p>
@@ -70,7 +42,7 @@
         {% else %}
         <p>Группы отсутствуют.</p>
         {% endif %}
-        <button class="button" onclick="location.href='/profile/{{ user.telegram_id }}?edit=true'">Редактировать профиль</button>
+        <button class="button" onclick="location.href='/profile/{{ profile_user.telegram_id }}?edit=true'">Редактировать профиль</button>
         {% endif %}
     </div>
 </div>

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -1,2 +1,11 @@
-<h1>Настройки</h1>
-<p>Раздел настроек находится в разработке.</p>
+{% extends "layout.html" %}
+{% block title %}Настройки{% endblock %}
+{% block content %}
+{% include "header.html" %}
+<div class="ui-layout">
+    <div id="main-content">
+        <h1>Настройки</h1>
+        <p>Раздел настроек находится в разработке.</p>
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -1,35 +1,7 @@
 {% extends "layout.html" %}
 {% block title %}Дашборд{% endblock %}
 {% block content %}
-<header class="top-bar">
-    <div class="top-left">
-        <h1 class="welcome"><a href="/">Привет, {{ user.first_name }}!</a></h1>
-    </div>
-    <div class="top-center">
-        <h2 class="page-title">{{ page_title }}</h2>
-    </div>
-    <div class="top-right">
-        {% if is_admin %}
-        <div class="admin-menu">
-            <div id="admin-button">Админ</div>
-            <div id="admin-dropdown" class="dropdown-menu hidden">
-                <a href="#" data-admin-endpoint="/admin/users">Пользователи</a>
-                <a href="#" data-admin-endpoint="/admin/groups">Группы</a>
-                <a href="#" data-admin-endpoint="/admin/settings">Настройки</a>
-            </div>
-        </div>
-        {% endif %}
-        <div class="profile-menu">
-            <div id="profile-button" class="profile-icon role-{{ role_name|lower }}">👤</div>
-            <div id="profile-dropdown" class="dropdown-menu hidden">
-                <div class="role">Роль: {{ role_name }}</div>
-                <a href="/profile/{{ user.telegram_id }}">Профиль</a>
-                <a href="/settings">Настройки</a>
-                <a href="/auth/logout" data-method="post">Выйти</a>
-            </div>
-        </div>
-    </div>
-</header>
+{% include "header.html" %}
 <div class="ui-layout">
     <div id="main-content">
     {% if groups %}


### PR DESCRIPTION
## Summary
- Move profile, settings and admin sections to standalone pages with a shared header
- Simplify client scripts to stop in-place rendering and allow normal navigation
- Provide context for new pages and admin routes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2f361ca08323acd3a05daeb31c46