### PR TITLE
Restore header and improve Telegram auth flow

### DIFF
--- a/tests/web/test_auth.py
+++ b/tests/web/test_auth.py
@@ -55,11 +55,11 @@ async def test_telegram_login_validation(client: AsyncClient):
         "auth_date": int(time.time()),
     }
     data["hash"] = _generate_hash(data)
-    response = await client.post("/auth/callback", data=data)
+    response = await client.post("/auth/tg/callback", data=data)
     assert response.status_code in {200, 303}
 
     data["hash"] = "invalid"
-    bad = await client.post("/auth/callback", data=data)
+    bad = await client.post("/auth/tg/callback", data=data)
     assert bad.status_code in {400, 401, 403}
 
 

--- a/web/templates/admin/index.html
+++ b/web/templates/admin/index.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Админ{% endblock %}
 {% block content %}
 <div class="ui-layout">

--- a/web/templates/auth/create_web_account.html
+++ b/web/templates/auth/create_web_account.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block title %}Создание аккаунта{% endblock %}
+{% block content %}
+<div class="ui-layout">
+    <h2>Создание аккаунта</h2>
+    {% if message %}
+    <p>{{ message }}</p>
+    <p><a href="/auth/login">Вернуться к входу</a></p>
+    {% else %}
+    <form class="ui-form" method="post" action="/auth/create_web_account">
+        <label>Username</label>
+        <input type="text" name="username" required>
+        <label>Password</label>
+        <input type="password" name="password" required>
+        <button type="submit" name="action" value="create" class="button">Создать</button>
+        <button type="submit" name="action" value="cancel" class="button">Отказаться</button>
+    </form>
+    {% endif %}
+</div>
+{% endblock %}
+

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Вход{% endblock %}
 {% block content %}
   <div class="ui-layout">
@@ -10,7 +10,9 @@
       <input type="password" name="password" required>
       <button type="submit" class="button">Войти</button>
     </form>
+    <p><a href="/auth/register">Регистрация</a></p>
 
+    {% if not telegram_id %}
     <h3>Или войдите через Telegram</h3>
     <div>
       <script async src="https://telegram.org/js/telegram-widget.js?22"
@@ -21,6 +23,7 @@
               data-request-access="write">
       </script>
     </div>
+    {% endif %}
   </div>
 
   <script>

--- a/web/templates/auth/register.html
+++ b/web/templates/auth/register.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Регистрация{% endblock %}
 {% block content %}
   <div class="ui-layout">

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -7,9 +7,8 @@
     <script type="module" src="{{ url_for('static', path='js/main.js') }}"></script>
 </head>
 <body>
-    {% if user is defined or current_user is defined %}
     {% include "header.html" %}
-    {% endif %}
     {% block content %}{% endblock %}
 </body>
 </html>
+

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -1,24 +1,32 @@
-{% set header_user = current_user if current_user is defined else user %}
-{% set header_role = current_role_name if current_role_name is defined else role_name %}
+{% set header_user = (current_user if current_user is defined else user) if (current_user is defined or user is defined) else None %}
+{% set header_role = (current_role_name if current_role_name is defined else role_name) if (current_role_name is defined or role_name is defined) else '' %}
 <header class="top-bar">
     <div class="top-left">
-        <h1 class="welcome"><a href="/">Привет, {{ header_user.first_name }}!</a></h1>
+        <a href="/" class="logo">🦁</a>
+        <a href="/" class="project-name">LeonidBot</a>
     </div>
     <div class="top-center">
         <h2 class="page-title">{{ page_title }}</h2>
     </div>
     <div class="top-right">
-        {% if is_admin %}
-        <div class="admin-menu"><a href="/admin">Админ</a></div>
-        {% endif %}
-        <div class="profile-menu">
-            <div id="profile-button" class="profile-icon role-{{ header_role|lower }}">👤</div>
-            <div id="profile-dropdown" class="dropdown-menu hidden">
-                <div class="role">Роль: {{ header_role }}</div>
-                <a href="/profile/{{ header_user.telegram_id }}">Профиль</a>
-                <a href="/settings">Настройки</a>
-                <a href="/auth/logout" data-method="post">Выйти</a>
+        {% if header_user %}
+            {% if is_admin %}
+            <div class="admin-menu"><a href="/admin">Админ</a></div>
+            {% endif %}
+            <div class="profile-menu">
+                <div id="profile-button" class="profile-icon role-{{ header_role|lower }}">👤</div>
+                <div id="profile-dropdown" class="dropdown-menu hidden">
+                    <div class="role">Роль: {{ header_role }}</div>
+                    <a href="/profile/{{ header_user.telegram_id }}">Профиль</a>
+                    <a href="/settings">Настройки</a>
+                    <a href="/auth/logout" data-method="post">Выйти</a>
+                </div>
             </div>
-        </div>
+        {% else %}
+            <nav class="guest-menu">
+                <a href="/auth/login">Вход</a>
+                <a href="/auth/register">Регистрация</a>
+            </nav>
+        {% endif %}
     </div>
 </header>

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Профиль{% endblock %}
 {% block content %}
 <div class="ui-layout">

--- a/web/templates/settings.html
+++ b/web/templates/settings.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Настройки{% endblock %}
 {% block content %}
 <div class="ui-layout">

--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "base.html" %}
 {% block title %}Дашборд{% endblock %}
 {% block content %}
 <div class="ui-layout">


### PR DESCRIPTION
## Summary
- Reinstate a global header with logo and project navigation
- Add registration link and hide Telegram widget when already authenticated
- Introduce web account creation flow for Telegram users and handle callbacks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6f3c0244832384030e209a67e77e