### PR TITLE
Handle existing enum type

### DIFF
--- a/alembic/versions/077d0b9ae78f_init.py
+++ b/alembic/versions/077d0b9ae78f_init.py
@@ -24,7 +24,7 @@ def upgrade() -> None:
     op.create_table('log_settings',
     sa.Column('id', sa.BigInteger(), nullable=False),
     sa.Column('chat_id', sa.BigInteger(), nullable=False),
-    sa.Column('level', sa.Enum('DEBUG', 'INFO', 'ERROR', name='loglevel'), nullable=True),
+    sa.Column('level', sa.Enum('DEBUG', 'INFO', 'ERROR', name='loglevel', create_type=False), nullable=True),
     sa.Column('updated_at', sa.DateTime(), nullable=True),
     sa.PrimaryKeyConstraint('id')
     )

--- a/core/models.py
+++ b/core/models.py
@@ -130,7 +130,10 @@ class LogSettings(Base):
 
     id = Column(BigInteger, primary_key=True)
     chat_id = Column(BigInteger, nullable=False)  # ID группы для логов
-    level = Column(Enum(LogLevel), default=LogLevel.ERROR)  # Уровень логирования
+    level = Column(
+        Enum(LogLevel, name="loglevel", create_type=False),
+        default=LogLevel.ERROR,
+    )  # Уровень логирования
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     def __repr__(self) -> str:  # pragma: no cover - debug aid


### PR DESCRIPTION
## Summary
- Prevent Alembic from recreating existing `loglevel` enum
- Reference existing enum in LogSettings model

## Testing
- `pytest -q`
- `flake8 core/models.py alembic/versions/077d0b9ae78f_init.py` *(fails: style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ab737a2d4883238af7a0c7d3e75c28