### PR TITLE
Handle duplicate username registration gracefully

### DIFF
--- a/tests/web/test_registration.py
+++ b/tests/web/test_registration.py
@@ -1,0 +1,22 @@
+import pytest
+from httpx import AsyncClient
+
+pytest_plugins = ["tests.web.test_auth"]
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_username(client: AsyncClient) -> None:
+    resp1 = await client.post(
+        "/auth/register",
+        data={"username": "alice", "password": "secret"},
+        follow_redirects=False,
+    )
+    assert resp1.status_code in {200, 303}
+
+    resp2 = await client.post(
+        "/auth/register",
+        data={"username": "alice", "password": "secret"},
+        follow_redirects=False,
+    )
+    assert resp2.status_code == 400
+    assert resp2.json()["detail"] == "username taken"

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -78,7 +78,10 @@ async def register(
     phone: str | None = Form(None),
 ):
     async with WebUserService() as service:
-        await service.register(username=username, password=password, email=email, phone=phone)
+        try:
+            await service.register(username=username, password=password, email=email, phone=phone)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     return RedirectResponse("/auth/login", status_code=status.HTTP_303_SEE_OTHER)
 
 
@@ -162,7 +165,10 @@ async def create_web_account(
         response.delete_cookie("telegram_id", path="/")
         return response
     async with WebUserService() as wsvc:
-        web_user = await wsvc.register(username=username, password=password)
+        try:
+            web_user = await wsvc.register(username=username, password=password)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
         async with TelegramUserService() as tsvc:
             tg_user = await tsvc.get_user_by_telegram_id(int(telegram_id))
         await wsvc.link_telegram(web_user.id, tg_user.id)


### PR DESCRIPTION
## Summary
- prevent unhandled exceptions when registering a user with an existing username
- test that duplicate usernames return HTTP 400

## Testing
- `flake8 --max-line-length=120 web/routes/auth.py`
- `flake8 --max-line-length=120 tests/web/test_registration.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7af93a788323b58b8b41cc4ff20b