### PR TITLE
Display login errors in web UI with detailed messages

### DIFF
--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -3,6 +3,9 @@
 {% block content %}
   <div class="ui-layout">
     <h2>Вход</h2>
+    {% if error %}
+    <div class="error">{{ error }}</div>
+    {% endif %}
     <form class="ui-form" method="post" action="/auth/login">
       <label>Username</label>
       <input type="text" name="username" required>


### PR DESCRIPTION
## Summary
- Show authentication and technical errors on the login page
- Provide template section for displaying error messages
- Test login failure paths and error reporting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8a803adc8323ac8607f80077781b