### PR TITLE
feat(auth): add scoped demo disclaimer on login page (no Python changes)

### DIFF
--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -27,6 +27,58 @@
       </script>
     </div>
     {% endif %}
+    <!-- Disclaimer: тестовое демо -->
+    <aside id="login-disclaimer" class="demo-disclaimer" role="note" aria-label="Дисклеймер демо">
+      <div class="dd-icon" aria-hidden="true">⚠️</div>
+      <div class="dd-body">
+        <strong>Важно:</strong> это <u>тестовое</u> демо-приложение. Мы не гарантируем отсутствие ошибок и сохранность данных — используйте на свой риск.
+        Показанный функционал можно приобрести полностью или частично:
+        <a href="https://t.me/LeoTechRu" target="_blank" rel="noopener noreferrer">@LeoTechRu</a>.
+      </div>
+      <button type="button" class="dd-close" aria-label="Скрыть уведомление">×</button>
+    </aside>
+
+    <style>
+      /* Стили ограничены страницей логина */
+      #login-disclaimer.demo-disclaimer {
+        --dd-bg1: #fff9e6;
+        --dd-bg2: #fff4cf;
+        --dd-border: #f3d37a;
+        --dd-text: #4a3b2c;
+
+        display: flex; align-items: flex-start; gap: 12px;
+        padding: 14px 16px; margin-top: 18px;
+        background: linear-gradient(180deg, var(--dd-bg1), var(--dd-bg2));
+        border: 1px solid var(--dd-border);
+        border-radius: 12px;
+        color: var(--dd-text);
+        box-shadow: 0 6px 18px rgba(0,0,0,.06);
+      }
+      #login-disclaimer .dd-icon { font-size: 20px; line-height: 1; margin-top: 2px; }
+      #login-disclaimer .dd-body { font-size: 14px; line-height: 1.5; }
+      #login-disclaimer .dd-body a { font-weight: 600; text-decoration: none; border-bottom: 1px dotted currentColor; }
+      #login-disclaimer .dd-body a:hover { text-decoration: underline; }
+      #login-disclaimer .dd-close {
+        margin-left: auto; border: 0; background: transparent;
+        font-size: 18px; line-height: 1; cursor: pointer; color: #7a6a55;
+      }
+      #login-disclaimer .dd-close:hover { color: #4a3b2c; }
+      /* Небольшое сжатие на узких экранах */
+      @media (max-width: 560px) {
+        #login-disclaimer.demo-disclaimer { padding: 12px; font-size: 14px; }
+      }
+    </style>
+
+    <script>
+      // Локальный скрипт только для этой страницы: закрыть дисклеймер
+      (function() {
+        var btn = document.currentScript.previousElementSibling.previousElementSibling.querySelector('.dd-close');
+        if (btn) btn.addEventListener('click', function() {
+          var box = document.getElementById('login-disclaimer');
+          if (box) box.remove();
+        });
+      })();
+    </script>
   </div>
 
   <script>


### PR DESCRIPTION
## Summary
- add dismissible demo disclaimer to login page with link to @LeoTechRu
- style disclaimer locally and include small script to hide it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb93a24a883239c185f23b47261e2