### PR TITLE
feat: restore telegram login widget

### DIFF
--- a/tests/web/test_auth.py
+++ b/tests/web/test_auth.py
@@ -63,6 +63,18 @@ async def test_telegram_login_validation(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_telegram_login_validation_get(client: AsyncClient):
+    data = {
+        "id": 124,
+        "first_name": "Test",
+        "auth_date": int(time.time()),
+    }
+    data["hash"] = _generate_hash(data)
+    response = await client.get("/auth/tg/callback", params=data)
+    assert response.status_code in {200, 303}
+
+
+@pytest.mark.asyncio
 async def test_middleware_redirects(client: AsyncClient):
     """Unauthenticated users should be redirected to login."""
     resp = await client.get("/admin", follow_redirects=False)

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -107,9 +107,13 @@ async def logout() -> RedirectResponse:
     return response
 
 
-@router.post("/tg/callback")
+@router.api_route("/tg/callback", methods=["GET", "POST"])
 async def telegram_callback(request: Request):
-    data = dict((await request.form()).items())
+    """Handle Telegram login callback from widget."""
+    if request.method == "POST":
+        data = dict((await request.form()).items())
+    else:
+        data = dict(request.query_params.items())
     if not verify_telegram_login(data):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Bad Telegram signature")
     telegram_id = int(data["id"])

--- a/web/templates/auth/login.html
+++ b/web/templates/auth/login.html
@@ -18,13 +18,15 @@
     {% if not telegram_id %}
     <h3>Или войдите через Telegram</h3>
     <div>
-      <script async src="https://telegram.org/js/telegram-widget.js?22"
-              data-telegram-login="{{ bot_username }}"
-              data-size="large"
-              data-userpic="false"
-              data-onauth="onTelegramAuth(user)"
-              data-request-access="write">
-      </script>
+      <script
+        async
+        src="https://telegram.org/js/telegram-widget.js?22"
+        data-telegram-login="{{ bot_username }}"
+        data-size="large"
+        data-userpic="false"
+        data-auth-url="/auth/tg/callback"
+        data-request-access="write"
+      ></script>
     </div>
     {% endif %}
     <!-- Disclaimer: тестовое демо -->
@@ -82,21 +84,10 @@
   </div>
 
   <script>
-  async function onTelegramAuth(user) {
-    const form = new URLSearchParams();
-    for (const [k,v] of Object.entries(user)) { form.append(k, v); }
-    const resp = await fetch('/auth/tg/callback', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: form.toString(),
-      credentials: 'same-origin'
-    });
-    if (resp.redirected) {
-      window.location = resp.url;
-    } else {
-      alert('Telegram account not linked');
-    }
-  }
+    // Функциональность авторизации через Telegram
+    // реализуется встроенным редиректом виджета по адресу
+    // `/auth/tg/callback`, поэтому дополнительный JavaScript
+    // здесь не требуется.
   </script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- show Telegram login widget on auth page using built-in redirect
- allow GET and POST callbacks for Telegram login
- test GET-based Telegram login

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc3499ab48323b658d37ca4691a3b