### PR TITLE
feat(web): redesign dashboard with widget grid

### DIFF
--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -1,67 +1,65 @@
 {% extends "base.html" %}
 {% block title %}Дашборд{% endblock %}
+
 {% block content %}
-<div class="dashboard">
-    <div class="profile-card">
-        <h2>Профиль</h2>
-        <p><strong>Full name:</strong> {{ profile_user.full_name or '' }}</p>
-        <p><strong>Username:</strong> {{ profile_user.username }}</p>
-        <p><strong>Email:</strong> {{ profile_user.email or 'не указано' }}</p>
-        <p><strong>Телефон:</strong> {{ profile_user.phone or 'не указан' }}</p>
-        <p><strong>День рождения:</strong> {{ profile_user.birthday.strftime('%d.%m.%Y') if profile_user.birthday else 'не указано' }}</p>
-        <p><strong>Язык:</strong> {{ profile_user.language or 'не указан' }}</p>
-        <p><strong>Роль:</strong> {{ profile_user.role }}</p>
-        <a href="/profile/{{ profile_user.username }}" class="button">Подробнее</a>
-    </div>
-    <div class="data-grid">
-        <section class="data-section">
-            <h3>Руководите группами</h3>
-            {% if owned_groups %}
-            <ul class="ui-table">
-            {% for g in owned_groups %}
-                <li>{{ g.title }}</li>
-            {% endfor %}
-            </ul>
-            {% else %}
-            <p>Нет</p>
-            {% endif %}
-        </section>
-        <section class="data-section">
-            <h3>Состоите в группах</h3>
-            {% if member_groups %}
-            <ul class="ui-table">
-            {% for g in member_groups %}
-                <li>{{ g.title }}</li>
-            {% endfor %}
-            </ul>
-            {% else %}
-            <p>Нет</p>
-            {% endif %}
-        </section>
-        <section class="data-section">
-            <h3>Ваши проекты</h3>
-            {% if owned_projects %}
-            <ul class="ui-table">
-            {% for p in owned_projects %}
-                <li>{{ p.name }}</li>
-            {% endfor %}
-            </ul>
-            {% else %}
-            <p>Проекты отсутствуют</p>
-            {% endif %}
-        </section>
-        <section class="data-section">
-            <h3>Участвуете в проектах</h3>
-            {% if member_projects %}
-            <ul class="ui-table">
-            {% for p in member_projects %}
-                <li>{{ p.name }}</li>
-            {% endfor %}
-            </ul>
-            {% else %}
-            <p>Нет</p>
-            {% endif %}
-        </section>
-    </div>
-</div>
+  <div class="dashboard">
+
+    {# — Профиль #}
+    {% set profile_body %}
+      <div class="grid grid-2 gap-md">
+        <div><div class="text-muted">Full name</div><div>{{ profile_user.full_name or '—' }}</div></div>
+        <div><div class="text-muted">Username</div><div>{{ profile_user.username }}</div></div>
+        <div><div class="text-muted">Email</div><div>{{ profile_user.email or 'не указано' }}</div></div>
+        <div><div class="text-muted">Телефон</div><div>{{ profile_user.phone or 'не указан' }}</div></div>
+        <div><div class="text-muted">День рождения</div><div>{{ profile_user.birthday.strftime('%d.%m.%Y') if profile_user.birthday else 'не указано' }}</div></div>
+        <div><div class="text-muted">Язык</div><div>{{ profile_user.language or 'не указан' }}</div></div>
+        <div><div class="text-muted">Роль</div><div class="badge">{{ profile_user.role }}</div></div>
+      </div>
+    {% endset %}
+    {% with title="Профиль", body=profile_body, classes="card--muted", span=2 %}
+      {% include "widgets/_card.html" %}
+    {% endwith %}
+
+    {# — KPI ряд: примеры (могут прийти из контекста) #}
+    {% with title="Фокус за неделю", label="Сфокусированные часы", value=kpi_hours or "0ч", delta=kpi_hours_delta or 0, classes="card--accent" %}
+      {% include "widgets/_kpi.html" %}
+    {% endwith %}
+    {% with title="Достижения", label="Выполнено целей", value=kpi_goals or "0", delta=kpi_goals_delta or 0 %}
+      {% include "widgets/_kpi.html" %}
+    {% endwith %}
+    {% with title="Здоровье", label="Health score", value=kpi_health or "—", delta=kpi_health_delta or 0 %}
+      {% include "widgets/_kpi.html" %}
+    {% endwith %}
+
+    {# — Графики/плейсхолдеры #}
+    {% with title="Активность по дням", span=2 %}
+      {% include "widgets/_chart_placeholder.html" %}
+    {% endwith %}
+    {% with title="Сон / энергия" %}
+      {% include "widgets/_chart_placeholder.html" %}
+    {% endwith %}
+
+    {# — Группы и проекты #}
+    {% set groups_owned = owned_groups|map(attribute='title')|list %}
+    {% set groups_items = groups_owned|map('string')|list %}
+    {% with title="Руководите группами", items=owned_groups or [] %}
+      {% include "widgets/_list.html" %}
+    {% endwith %}
+
+    {% with title="Состоите в группах", items=member_groups or [] %}
+      {% include "widgets/_list.html" %}
+    {% endwith %}
+    {% with title="Ваши проекты", items=owned_projects or [] %}
+      {% include "widgets/_list.html" %}
+    {% endwith %}
+    {% with title="Участвуете в проектах", items=member_projects or [] %}
+      {% include "widgets/_list.html" %}
+    {% endwith %}
+
+    {# — Таймлайн дня #}
+    {% with title="Сегодня", events=day_timeline or [] %}
+      {% include "widgets/_timeline.html" %}
+    {% endwith %}
+
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- redesign dashboard template to use grid and modular widgets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0f38c760832397787f819be941c6