### PR TITLE
Restore profile card on dashboard

### DIFF
--- a/web/templates/start.html
+++ b/web/templates/start.html
@@ -6,16 +6,22 @@
     <div class="dashboard">
 
       {# — Профиль #}
-      <section class="card card--muted span-2">
+      <section class="card span-2" id="card-profile">
         <div class="card-title">Профиль</div>
         <div style="display:grid;grid-template-columns:1fr 2fr;gap:6px 12px">
-          <div class="ui2-muted">Полное имя</div><div>{{ profile_user.full_name or '—' }}</div>
+          <div class="ui2-muted">Full name</div><div>{{ profile_user.full_name or '—' }}</div>
           <div class="ui2-muted">Username</div><div>{{ profile_user.username }}</div>
           <div class="ui2-muted">Email</div><div>{{ profile_user.email or 'не указано' }}</div>
           <div class="ui2-muted">Телефон</div><div>{{ profile_user.phone or 'не указан' }}</div>
           <div class="ui2-muted">День рождения</div><div>{{ profile_user.birthday.strftime('%d.%m.%Y') if profile_user.birthday else 'не указано' }}</div>
           <div class="ui2-muted">Язык</div><div>{{ profile_user.language or 'не указан' }}</div>
-          <div class="ui2-muted">Роль</div><div>{{ profile_user.role }}</div>
+          <div class="ui2-muted">Роль</div>
+          <div>
+            <button type="button" class="role-badge" data-role="{{ profile_user.role }}">{{ profile_user.role }}</button>
+          </div>
+        </div>
+        <div style="text-align:right;margin-top:12px;">
+          <a class="button" href="/profile/{{ profile_user.username }}">Подробнее</a>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- restore profile card in dashboard with role badge and details link

## Testing
- `flake8 web --exclude=venv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1dca39588323b1f59defc8dc1b8c