### PR TITLE
feat(web): add role badge with help modal

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -463,3 +463,24 @@ body.compact .admin-panel {
 }
 /* === /ui2 === */
 
+/* ui2: role badge + modal */
+.role-badge{
+  display:inline-block; border:none; cursor:pointer;
+  padding:4px 10px; border-radius:12px; font:inherit;
+  background: var(--color-accent-purple); color:#fff;
+}
+.role-badge:hover{ filter:brightness(0.95); }
+
+.role-help-modal.hidden{ display:none; }
+.role-help-modal{
+  position:fixed; inset:0; display:flex; align-items:center; justify-content:center;
+  background: rgba(17,24,39,.45); z-index:1000;
+}
+.role-help-card{
+  background:#fff; border-radius:12px; padding:18px 20px; width:min(560px, 92vw);
+  box-shadow:0 10px 30px rgba(0,0,0,.18);
+}
+.role-help-card .title{ font-weight:700; margin-bottom:8px; }
+.role-help-card .text{ color:#4b5563; }
+.role-help-card .actions{ text-align:right; margin-top:14px; }
+

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -101,3 +101,52 @@ document.addEventListener('DOMContentLoaded', () => {
     applyNoGridIfNeeded();
   }
 })();
+
+// ui2: role help modal (idempotent)
+(function(){
+  const ROLE_HELP = {
+    admin: 'Админ: полные права администрирования.',
+    moderator: 'Модератор: управление контентом/группами.',
+    multiplayer: 'Совместная работа: доступ к групповым функциям.',
+    single: 'Обычный пользователь: индивидуальный режим.',
+    ban: 'Заблокирован: доступ к приложению закрыт. Напишите администратору.'
+  };
+
+  function ensureModal(){
+    if (document.getElementById('role-help-modal')) return;
+    const wrap = document.createElement('div');
+    wrap.id = 'role-help-modal';
+    wrap.className = 'role-help-modal hidden';
+    wrap.innerHTML = `
+      <div class="role-help-card">
+        <div class="title">Роль пользователя</div>
+        <div class="text" id="role-help-text"></div>
+        <div class="actions"><button id="role-help-close" class="button">Понятно</button></div>
+      </div>`;
+    wrap.addEventListener('click', (e)=>{ if (!e.target.closest('.role-help-card')) hide(); });
+    document.body.appendChild(wrap);
+    document.getElementById('role-help-close').addEventListener('click', hide);
+    document.addEventListener('keydown', (e)=>{ if (e.key === 'Escape') hide(); });
+  }
+
+  function show(role){
+    ensureModal();
+    const wrap = document.getElementById('role-help-modal');
+    document.getElementById('role-help-text').textContent =
+      ROLE_HELP[role] || `Роль: ${role}`;
+    wrap.classList.remove('hidden');
+  }
+  function hide(){
+    const wrap = document.getElementById('role-help-modal');
+    if (wrap) wrap.classList.add('hidden');
+  }
+
+  function onClick(e){
+    const b = e.target.closest('[data-role]');
+    if (!b) return;
+    e.preventDefault();
+    show((b.dataset.role || '').trim());
+  }
+
+  document.addEventListener('click', onClick);
+})();

--- a/web/templates/header.html
+++ b/web/templates/header.html
@@ -16,7 +16,10 @@
         <div class="profile-menu">
             <div id="profile-button" class="profile-icon role-{{ header_role|lower }}">👤</div>
             <div id="profile-dropdown" class="dropdown-menu hidden">
-                <div class="role">Роль: {{ header_role }}</div>
+                <div class="role">
+                    Роль:
+                    <button type="button" class="role-badge" data-role="{{ header_role }}">{{ header_role }}</button>
+                </div>
                 {% if header_user.telegram_id is defined %}
                 <a href="/profile/{{ header_user.telegram_id }}">Профиль</a>
                 {% else %}

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -44,7 +44,12 @@
           <div><div class="text-muted">Телефон</div><div>{{ profile_user.phone or 'не указан' }}</div></div>
           <div><div class="text-muted">День рождения</div><div>{{ profile_user.birthday.strftime('%d.%m.%Y') if profile_user.birthday else 'не указано' }}</div></div>
           <div><div class="text-muted">Язык</div><div>{{ profile_user.language or 'не указан' }}</div></div>
-          <div><div class="text-muted">Роль</div><div class="badge">{{ profile_user.role }}</div></div>
+          <div>
+            <div class="text-muted">Роль</div>
+            <div>
+              <button type="button" class="role-badge" data-role="{{ profile_user.role }}">{{ profile_user.role }}</button>
+            </div>
+          </div>
         </div>
         <div style="display:flex; justify-content:flex-end; margin-top:1rem;">
           <button class="button" onclick="location.href='/profile/{{ profile_user.username }}?edit=true'">Редактировать профиль</button>


### PR DESCRIPTION
## Summary
- make user roles clickable badges in header and profile
- add CSS styles and JS modal to explain roles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2031a91483238ca97c72b0acab4c