### PR TITLE
feat(web): redirect banned users to ban page

### DIFF
--- a/web/routes/settings.py
+++ b/web/routes/settings.py
@@ -15,7 +15,16 @@ templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 
 
 @router.get("/settings", include_in_schema=False)
-async def settings_page(request: Request, current_user: WebUser = Depends(get_current_web_user)):
+async def settings_page(
+    request: Request,
+    current_user: WebUser = Depends(get_current_web_user),
+):
+    if current_user and current_user.role == "ban":
+        from fastapi.responses import RedirectResponse
+        from fastapi import status
+        return RedirectResponse(
+            "/ban", status_code=status.HTTP_307_TEMPORARY_REDIRECT
+        )
     context = {
         "user": current_user,
         "role_name": current_user.role,


### PR DESCRIPTION
## Summary
- add `/ban` page and guard redirecting banned users
- protect profile and settings routes from banned users

## Testing
- `flake8 web/routes/index.py web/routes/profile.py web/routes/settings.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae23f5f0e88323ae3906854ff17dfe